### PR TITLE
[bug 1215125] Fix whimsical locale in admin

### DIFF
--- a/fjord/base/middleware.py
+++ b/fjord/base/middleware.py
@@ -160,4 +160,7 @@ class LocaleURLMiddleware(object):
 
         request.path_info = '/' + prefixer.shortened_path
         request.locale = prefixer.locale
-        translation.activate(prefixer.locale)
+        # prefixer.locale can be '', but we need a real locale code to activate
+        # otherwise the request uses the previously handled request's
+        # translations.
+        translation.activate(prefixer.locale or settings.LANGUAGE_CODE)


### PR DESCRIPTION
Django 1.8 changed trans_real.activate such that if you pass in a ''
language, then it does nothing. Since prefixer.locale is '' when
handling an /admin/ request, the request gets handled with the
previously handled request's activated translations.

This fixes that so that if prefixer.locale is '', then we use the
settings.LANGUAGE_CODE to activate the translations.

r?